### PR TITLE
feat: Support for Custom PDS's

### DIFF
--- a/src/bluesky-integration.ts
+++ b/src/bluesky-integration.ts
@@ -66,14 +66,15 @@ class BlueskyIntegration
 
     const username = settings?.account?.username;
     const appPassword = settings?.account?.appPassword;
+    const service = settings?.account?.service;
 
-    if (!username || !appPassword) {
+    if (!username || !appPassword || !service) {
       logger.warn("Bluesky Integration account login is missing");
       return;
     }
 
     try {
-      this.bot = new BlueskyBot();
+      this.bot = new BlueskyBot({service: service});
 
       await this.bot.login({ identifier: username, password: appPassword });
     } catch (error) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,6 +38,16 @@ export const BLUESKY_INTEGRATION_DEFINITION: IntegrationDefinition<BlueskyIntegr
               required: true,
             },
           },
+          service: {
+            type: "string",
+            default: "https://bsky.social",
+            title: "Bluesky Service",
+            description:
+              "Your Bluesky PDS. For most users, the default is fine. You'll most likely know if you need to change this",
+            validation: {
+                required: true,
+            },
+          },
         },
       },
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export type BlueskyIntegrationSettings = {
   account: {
     username: string;
     appPassword: string;
+    service: string;
   };
 };
 


### PR DESCRIPTION
This PR adds the ability for the bot to log into a PDS that isn't bsky.social. Just an additional third account object, which defaults to bsky.social. I'm a bit rough on my JS, so feel free to toss any critiques, but I've tested, and the script can successfully log in and post on my account now. I am unable to test on a bsky.social account, but there shouldn't be any issues.